### PR TITLE
asbestos-test-engine: TestScript Assert support for validateProfileId with matchbox

### DIFF
--- a/asbestos-service-properties/src/main/java/gov/nist/asbestos/serviceproperties/ServicePropertiesEnum.java
+++ b/asbestos-service-properties/src/main/java/gov/nist/asbestos/serviceproperties/ServicePropertiesEnum.java
@@ -12,6 +12,7 @@ public enum ServicePropertiesEnum {
     FHIR_TOOLKIT_BASE("fhirToolkitBase"),
     FHIR_TOOLKIT_VERSION("fhirToolkitVersion"),
     HAPI_FHIR_BASE("hapiFhirBase"),
+    VALIDATION_FHIR_BASE("validationFhirBase"),
     CAT_EXTERNAL_PATIENT_SERVER_FHIR_BASE("patientServerBase"),
 //    LIMITED_CHANNEL_CAPABILITY_STATMENT_FILE("limitedChannelCapabilityStatementFile"),
 //    XDS_CHANNEL_CAPABILITY_STATEMENT_FILE("xdsChannelCapabilityStatementFile"),

--- a/asbestos-test-engine/pom.xml
+++ b/asbestos-test-engine/pom.xml
@@ -28,4 +28,31 @@
             <version>4.2.0</version><!-- asbts -->
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+            Surefire is to run Unit Tests *Test.java
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>1.2.0-M1</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>5.2.0-M1</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+        </plugins>
+    </build>
+
 </project>

--- a/asbestos-test-engine/src/main/java/gov/nist/asbestos/testEngine/engine/ActionReporter.java
+++ b/asbestos-test-engine/src/main/java/gov/nist/asbestos/testEngine/engine/ActionReporter.java
@@ -42,7 +42,7 @@ class ActionReporter implements TestDef {
                                    Reporter reporter, TestScript.SetupActionOperationComponent op) {
         String request = "";
         if (wrapper != null) {
-            String url = wrapper.getHttpBase().getUri().toString();
+            String url = (wrapper.getHttpBase().getUri() != null ? wrapper.getHttpBase().getUri().toString() : "");
             request = "### " + wrapper.getHttpBase().getVerb() + " [" + url + "](" + url + ")";
         }
 

--- a/asbestos-test-engine/src/main/java/gov/nist/asbestos/testEngine/engine/GenericFhirClient.java
+++ b/asbestos-test-engine/src/main/java/gov/nist/asbestos/testEngine/engine/GenericFhirClient.java
@@ -1,0 +1,227 @@
+package gov.nist.asbestos.testEngine.engine;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.api.EncodingEnum;
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.impl.BaseHttpClientInvocation;
+import ca.uhn.fhir.rest.client.impl.GenericClient;
+import ca.uhn.fhir.rest.client.method.HttpPostClientInvocation;
+import ca.uhn.fhir.rest.client.method.IClientResponseHandler;
+import ca.uhn.fhir.rest.client.method.MethodUtil;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
+import com.google.common.base.Charsets;
+import org.apache.commons.io.IOUtils;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * ValidationClient extends the Generice
+ *
+ * @author oliveregger
+ */
+public class GenericFhirClient extends GenericClient {
+
+	static final public String testServer = "http://localhost:8080/matchboxv3/fhir";
+
+	public GenericFhirClient(FhirContext theContext, String theServerBase) {
+		super(theContext, null, theServerBase, null);
+		setDontValidateConformance(true);
+		theContext.getRestfulClientFactory().setSocketTimeout(600 * 1000);
+	}
+
+	public GenericFhirClient(FhirContext theContext) {
+		this(theContext, testServer);
+	}
+
+	private final class OutcomeResponseHandler implements IClientResponseHandler<MethodOutcome> {
+
+		private OutcomeResponseHandler() {
+			super();
+		}
+
+		@Override
+		public MethodOutcome invokeClient(String theResponseMimeType,
+													 InputStream theResponseInputStream,
+													 int theResponseStatusCode,
+													 Map<String, List<String>> theHeaders) throws BaseServerResponseException {
+			MethodOutcome response = MethodUtil.process2xxResponse(getFhirContext(),
+																					 theResponseStatusCode,
+																					 theResponseMimeType,
+																					 theResponseInputStream,
+																					 theHeaders);
+			response.setCreatedUsingStatusCode(theResponseStatusCode);
+			response.setResponseHeaders(theHeaders);
+			return response;
+		}
+	}
+
+	public static BaseHttpClientInvocation createOperationInvocation(FhirContext theContext,
+																						  String theOperationName,
+																						  String theInput,
+																						  Map<String, List<String>> urlParams) {
+		StringBuilder b = new StringBuilder();
+		if (b.length() > 0) {
+			b.append('/');
+		}
+		if (!theOperationName.startsWith("$")) {
+			b.append("$");
+		}
+		b.append(theOperationName);
+		BaseHttpClientInvocation.appendExtraParamsWithQuestionMark(urlParams, b, b.indexOf("?") == -1);
+		return new HttpPostClientInvocation(theContext, theInput, false, b.toString());
+	}
+
+	/**
+	 * Performs the $validate operation with a direct POST (see
+	 * http://hl7.org/fhir/resource-operation-validate.html#examples) and the profile specified as a parameter (not the
+	 * Parameters syntact).
+	 *
+	 * @param theContents content to validate
+	 * @param theProfile  optional: profile to validate against
+	 * @return
+	 */
+	public IBaseOperationOutcome validate(String theContents, String theProfile) {
+		setEncoding(EncodingEnum.detectEncoding(theContents));
+		Map<String, List<String>> theExtraParams = null;
+		if (theProfile != null) {
+			theExtraParams = new HashMap<String, List<String>>();
+			List<String> profiles = new ArrayList<String>();
+			profiles.add(theProfile);
+			theExtraParams.put("profile", profiles);
+		}
+		OutcomeResponseHandler binding = new OutcomeResponseHandler();
+		BaseHttpClientInvocation clientInvoke = createOperationInvocation(getFhirContext(),
+																								"$validate",
+																								theContents,
+																								theExtraParams);
+		MethodOutcome resp = invokeClient(getFhirContext(),
+													 binding,
+													 clientInvoke,
+													 null,
+													 null,
+													 false,
+													 null,
+													 null,
+													 null,
+													 null,
+													 null);
+		return resp.getOperationOutcome();
+	}
+
+
+	private String getStructureMapTransformOperation(Map<String, List<String>> urlParams) {
+		StringBuilder b = new StringBuilder();
+		b.append("StructureMap/$transform");
+		BaseHttpClientInvocation.appendExtraParamsWithQuestionMark(urlParams, b, b.indexOf("?") == -1);
+		return b.toString();
+	}
+
+	public BaseHttpClientInvocation createStructureMapTransformInvocation(FhirContext theContext,
+																								 String theInput,
+																								 Map<String, List<String>> urlParams) {
+		return new HttpPostClientInvocation(theContext, theInput, false, getStructureMapTransformOperation(urlParams));
+	}
+
+	public BaseHttpClientInvocation createStructureMapTransformInvocation(FhirContext theContext,
+																								 IBaseResource resource,
+																								 Map<String, List<String>> urlParams) {
+		return new HttpPostClientInvocation(theContext, resource, getStructureMapTransformOperation(urlParams));
+	}
+
+
+	/**
+	 * Performs the $transform operation with a direct POST and returning a Resource
+	 *
+	 * @return
+	 */
+	public IBaseResource convert(String theContents,
+										  EncodingEnum contentEndoding,
+										  String sourceMapUrl,
+										  String acceptHeader) {
+		setEncoding(contentEndoding);
+		Map<String, List<String>> theExtraParams = null;
+		if (sourceMapUrl != null) {
+			theExtraParams = new HashMap<String, List<String>>();
+			List<String> urls = new ArrayList<String>();
+			urls.add(sourceMapUrl);
+			theExtraParams.put("source", urls);
+		}
+		ResourceResponseHandler<IBaseResource> binding = new ResourceResponseHandler<IBaseResource>();
+		BaseHttpClientInvocation clientInvoke = createStructureMapTransformInvocation(getFhirContext(),
+																												theContents,
+																												theExtraParams);
+		return invokeClient(getFhirContext(),
+								  binding,
+								  clientInvoke,
+								  null,
+								  null,
+								  false,
+								  null,
+								  null,
+								  null,
+								  acceptHeader,
+								  null);
+	}
+
+	private final class StringResponseHandler implements IClientResponseHandler<String> {
+
+		@Override
+		public String invokeClient(String theResponseMimeType,
+											InputStream theResponseInputStream,
+											int theResponseStatusCode,
+											Map<String, List<String>> theHeaders)
+			throws IOException, BaseServerResponseException {
+			return IOUtils.toString(theResponseInputStream, Charsets.UTF_8);
+		}
+	}
+
+	/**
+	 * Performs the $transform operation with a direct POST and returning a Resource
+	 *
+	 * @return
+	 */
+	public String convert(IBaseResource resource,
+								 EncodingEnum contentEndoding,
+								 String sourceMapUrl,
+								 String acceptHeader) {
+		setEncoding(contentEndoding);
+		Map<String, List<String>> theExtraParams = null;
+		if (sourceMapUrl != null) {
+			theExtraParams = new HashMap<String, List<String>>();
+			List<String> urls = new ArrayList<String>();
+			urls.add(sourceMapUrl);
+			theExtraParams.put("source", urls);
+		}
+		BaseHttpClientInvocation clientInvoke = createStructureMapTransformInvocation(getFhirContext(),
+																												resource,
+																												theExtraParams);
+		return invokeClient(getFhirContext(),
+								  new StringResponseHandler(),
+								  clientInvoke,
+								  null,
+								  null,
+								  false,
+								  null,
+								  null,
+								  null,
+								  acceptHeader,
+								  null);
+	}
+
+	public CapabilityStatement retrieveCapabilityStatement() {
+		IGenericClient client = getFhirContext().newRestfulGenericClient(testServer);
+		CapabilityStatement capabilityStatement = client.capabilities().ofType(CapabilityStatement.class).execute();
+		return capabilityStatement;
+	}
+
+}

--- a/asbestos-test-engine/src/main/java/gov/nist/asbestos/testEngine/engine/TestEngine.java
+++ b/asbestos-test-engine/src/main/java/gov/nist/asbestos/testEngine/engine/TestEngine.java
@@ -1,5 +1,6 @@
 package gov.nist.asbestos.testEngine.engine;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import gov.nist.asbestos.client.Base.EC;
 import gov.nist.asbestos.client.Base.ParserBase;
@@ -11,6 +12,8 @@ import gov.nist.asbestos.client.debug.TestScriptDebugState;
 import gov.nist.asbestos.client.resolver.Ref;
 import gov.nist.asbestos.client.resolver.ResourceCacheMgr;
 import gov.nist.asbestos.client.resolver.ResourceWrapper;
+import gov.nist.asbestos.serviceproperties.ServiceProperties;
+import gov.nist.asbestos.serviceproperties.ServicePropertiesEnum;
 import gov.nist.asbestos.simapi.validation.Val;
 import gov.nist.asbestos.simapi.validation.ValE;
 import gov.nist.asbestos.testEngine.engine.fixture.FixtureComponent;
@@ -65,6 +68,7 @@ public class TestEngine  implements TestDef {
     private final FixtureMgr fixtureMgr = new FixtureMgr();
     private Val val;
     private ValE engineVal;
+    private ValidationClient validationClient = null;
     private FhirClient fhirClient = null;
     private FhirClient fhirClientForFixtures;
     private List<String> errors;
@@ -128,6 +132,9 @@ public class TestEngine  implements TestDef {
         if (moduleIds != null) {
             this.moduleIds.addAll(moduleIds);
         }
+        ServicePropertiesEnum key = ServicePropertiesEnum.FHIR_VALIDATION_SERVER;
+        String fhirValidationServer = ServiceProperties.getInstance().getPropertyOrThrow(key);
+        validationClient = new ValidationClient(FhirContext.forR4Cached(), fhirValidationServer);
     }
 
     public TestEngine setFixtures(Map<String, FixtureComponent> fixtures) {
@@ -890,7 +897,7 @@ public class TestEngine  implements TestDef {
                             .setExternalVariables(externalVariables)
                             .setVal(vale)
                             .setOpReport(report))
-//                    .setTestReport(testReport)
+                    .setTestReport(testReport)
                     .setTestScript(testScript)
                     .setIsRequest(isRequest);
             runner
@@ -1802,6 +1809,15 @@ public class TestEngine  implements TestDef {
 
     public TestEngine setFhirClient(FhirClient fhirClient) {
         this.fhirClient = fhirClient;
+        return this;
+    }
+
+    public ValidationClient getValidationClient() {
+        return this.validationClient;
+    }
+
+    public TestEngine setValidationClient(ValidationClient validationClient) {
+        this.validationClient = validationClient;
         return this;
     }
 

--- a/asbestos-test-engine/src/main/java/gov/nist/asbestos/testEngine/engine/ValidationClient.java
+++ b/asbestos-test-engine/src/main/java/gov/nist/asbestos/testEngine/engine/ValidationClient.java
@@ -1,0 +1,110 @@
+package gov.nist.asbestos.testEngine.engine;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.api.EncodingEnum;
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.client.impl.BaseHttpClientInvocation;
+import ca.uhn.fhir.rest.client.impl.GenericClient;
+import ca.uhn.fhir.rest.client.method.HttpPostClientInvocation;
+import ca.uhn.fhir.rest.client.method.IClientResponseHandler;
+import ca.uhn.fhir.rest.client.method.MethodUtil;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * ValidationClient extends the Generice
+ *
+ * @author oliveregger
+ */
+public class ValidationClient extends GenericClient {
+
+
+	public ValidationClient(FhirContext theContext, String theServerBase) {
+		super(theContext, null, theServerBase, null);
+		setDontValidateConformance(true);
+		theContext.getRestfulClientFactory().setSocketTimeout(600 * 1000);
+	}
+
+	private final class OutcomeResponseHandler implements IClientResponseHandler<MethodOutcome> {
+
+		private OutcomeResponseHandler() {
+			super();
+		}
+
+		@Override
+		public MethodOutcome invokeClient(String theResponseMimeType,
+													 InputStream theResponseInputStream,
+													 int theResponseStatusCode,
+													 Map<String, List<String>> theHeaders) throws BaseServerResponseException {
+			MethodOutcome response = MethodUtil.process2xxResponse(getFhirContext(),
+																					 theResponseStatusCode,
+																					 theResponseMimeType,
+																					 theResponseInputStream,
+																					 theHeaders);
+			response.setCreatedUsingStatusCode(theResponseStatusCode);
+			response.setResponseHeaders(theHeaders);
+			return response;
+		}
+	}
+
+	public static BaseHttpClientInvocation createValidationInvocation(FhirContext theContext,
+																							String theOperationName,
+																							String theInput,
+																							Map<String, List<String>> urlParams) {
+		StringBuilder b = new StringBuilder();
+		if (b.length() > 0) {
+			b.append('/');
+		}
+		if (!theOperationName.startsWith("$")) {
+			b.append("$");
+		}
+		b.append(theOperationName);
+		BaseHttpClientInvocation.appendExtraParamsWithQuestionMark(urlParams, b, b.indexOf("?") == -1);
+		return new HttpPostClientInvocation(theContext, theInput, false, b.toString());
+	}
+
+	/**
+	 * Performs the $validate operation with a direct POST (see
+	 * http://hl7.org/fhir/resource-operation-validate.html#examples) and the profile specified as a parameter (not the
+	 * Parameters syntax).
+	 *
+	 * @param theContents content to validate
+	 * @param theProfile  optional: profile to validate against
+	 * @return
+	 */
+	public IBaseOperationOutcome validate(String theContents, String theProfile) {
+		setEncoding(EncodingEnum.detectEncoding(theContents));
+		Map<String, List<String>> theExtraParams = null;
+		if (theProfile != null) {
+			theExtraParams = new HashMap<String, List<String>>();
+			List<String> profiles = new ArrayList<String>();
+			profiles.add(theProfile);
+			theExtraParams.put("profile", profiles);
+		}
+		OutcomeResponseHandler binding = new OutcomeResponseHandler();
+		BaseHttpClientInvocation clientInvoke = createValidationInvocation(getFhirContext(),
+																								 "$validate",
+																								 theContents,
+																								 theExtraParams);
+		MethodOutcome resp = invokeClient(getFhirContext(),
+													 binding,
+													 clientInvoke,
+													 null,
+													 null,
+													 false,
+													 null,
+													 null,
+													 null,
+													 null,
+													 null);
+		return resp.getOperationOutcome();
+	}
+
+}

--- a/asbestos-test-engine/src/main/java/gov/nist/asbestos/testEngine/engine/assertion/AssertionContext.java
+++ b/asbestos-test-engine/src/main/java/gov/nist/asbestos/testEngine/engine/assertion/AssertionContext.java
@@ -16,9 +16,11 @@ public interface AssertionContext {
     boolean getWarningOnly();
     TestScript.SetupActionAssertComponent getCurrentAssert();
     TestReport.SetupActionAssertComponent getCurrentAssertReport();
+    TestReport getTestReport();
     ValE getVal();
     String getType();
     String getLabel();
+    String getProfile(String id);
     FixtureLabels getFixtureLabels();
     FixtureLabels getCompareToFixtureLabels();
     VariableMgr getVariableMgr();
@@ -26,4 +28,5 @@ public interface AssertionContext {
     boolean isRequest();
 
     boolean validate();
+    
 }

--- a/asbestos-test-engine/src/main/java/gov/nist/asbestos/testEngine/engine/assertion/ValidateProfileAssertion.java
+++ b/asbestos-test-engine/src/main/java/gov/nist/asbestos/testEngine/engine/assertion/ValidateProfileAssertion.java
@@ -1,0 +1,121 @@
+package gov.nist.asbestos.testEngine.engine.assertion;
+
+import gov.nist.asbestos.testEngine.engine.FixtureLabels;
+import gov.nist.asbestos.testEngine.engine.Reporter;
+import gov.nist.asbestos.testEngine.engine.TestEngine;
+import gov.nist.asbestos.testEngine.engine.ValidationClient;
+import gov.nist.asbestos.testEngine.engine.fixture.FixtureComponent;
+import org.hl7.fhir.r4.model.BaseResource;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.OperationOutcome.OperationOutcomeIssueComponent;
+import org.hl7.fhir.r4.model.TestReport.TestReportActionResult;
+
+import java.io.IOException;
+
+public class ValidateProfileAssertion {
+
+    public static boolean run(AssertionContext ctx) {
+        if (!ctx.validate())
+            return false;
+
+        FixtureComponent sourceFixture = ctx.getSource();
+
+        String profile = ctx.getProfile(ctx.getCurrentAssert().getValidateProfileId());
+        if (profile == null) {
+            Reporter.reportFail(ctx, "Profile not found for profileId " + ctx.getCurrentAssert().getValidateProfileId());
+            return false;
+        }
+
+        BaseResource sourceR = sourceFixture.getResourceResource();  // sut
+        if (sourceR == null) {
+            Reporter.reportFail(ctx, "No source");
+            return false;
+        }
+
+        // change to access raw fixture in the future
+        String content;
+        try {
+            content = new org.hl7.fhir.r4.formats.JsonParser().composeString((Resource) sourceR);
+        } catch (IOException e) {
+            Reporter.reportFail(ctx, "serializing failed for fixture " + sourceFixture.getId());
+            return false;
+        }
+
+        ValidationClient client = ((TestEngine) ctx.getTestDef()).getValidationClient();
+        OperationOutcome outcome = (OperationOutcome) client.validate(content, profile);
+
+        org.hl7.fhir.r4.model.TestReport.SetupActionAssertComponent assertReport = ctx.getCurrentAssertReport();
+    
+        assertReport.setResult(TestReportActionResult.PASS);
+        assertReport.setMessage("Validation of profile "+profile+ "for fixture "+sourceFixture.getId());
+        assertReport.setDetail(outcome.getIssueFirstRep().getDiagnostics());
+        
+        Extension extension = assertReport.addExtension();
+        extension.setUrl("http://hl7.org/fhir/StructureDefinition/referencesContained");
+        extension.setValue(new org.hl7.fhir.r4.model.Reference("#"+outcome.getId()));
+        ctx.getTestReport().addContained(outcome);
+        
+        int failures = getValidationFailures(outcome);
+        if (getValidationWarnings(outcome)>0) {
+            assertReport.setResult(TestReportActionResult.WARNING);
+        }
+        if (getValidationFailures(outcome)>0) {
+            assertReport.setResult(TestReportActionResult.FAIL);
+        }
+
+        if (failures == 0) {
+            Reporter.reportPass(ctx, "pass");
+            return true;
+        } else {
+            Reporter.reportFail(ctx, "validation failed for profile "+profile);
+            return false;
+        }
+    }
+
+    public static void build(AssertionContext ctx, FixtureComponent source, FixtureComponent reference) {
+        FixtureLabels sourceLabels = new FixtureLabels(ctx.getTestDef(), source, FixtureLabels.Source.RESPONSE);
+        sourceLabels.setReference(source);
+        FixtureLabels referenceLabels = new FixtureLabels(ctx.getTestDef(), reference, FixtureLabels.Source.REQUEST);
+        referenceLabels.setReference(reference);
+        String sourceRef = sourceLabels.getReference();
+        if (sourceLabels.getRawReference() == null) {
+            if (sourceLabels.getLabel() != null) {
+                sourceRef = sourceLabels.getLabel();
+            } else {
+                sourceRef = "(fixture)";
+            }
+        }
+        Reporter.assertDescription(ctx.getCurrentAssertReport(), "**Compare** " + sourceRef + " to **Reference** " + referenceLabels.getReference());
+    }
+
+    static public int getValidationWarnings(OperationOutcome outcome) {
+		int fails = 0;
+		if (outcome != null && outcome.getIssue() != null) {
+			for (OperationOutcomeIssueComponent issue : outcome.getIssue()) {
+				if (IssueSeverity.WARNING == issue.getSeverity()) {
+					++fails;
+				}
+			}
+		}
+		return fails;
+	}
+
+    static public int getValidationFailures(OperationOutcome outcome) {
+		int fails = 0;
+		if (outcome != null && outcome.getIssue() != null) {
+			for (OperationOutcomeIssueComponent issue : outcome.getIssue()) {
+				if (IssueSeverity.FATAL == issue.getSeverity()) {
+					++fails;
+				}
+				if (IssueSeverity.ERROR == issue.getSeverity()) {
+					++fails;
+				}
+			}
+		}
+		return fails;
+	}
+
+}

--- a/asbestos-test-engine/src/main/resources/autoCreate/TestScript.xml
+++ b/asbestos-test-engine/src/main/resources/autoCreate/TestScript.xml
@@ -2,6 +2,8 @@
 
 <TestScript xmlns="http://hl7.org/fhir">
     <fixture id="F1">
+        <autocreate value="true"/>
+        <autodelete value="true"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/AssertFixtureTest.java
+++ b/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/AssertFixtureTest.java
@@ -2,42 +2,48 @@ package gov.nist.asbestos.testEngine.engine;
 
 import gov.nist.asbestos.client.Base.ParserBase;
 import gov.nist.asbestos.simapi.validation.Val;
+
+import org.hl7.fhir.exceptions.FHIRFormatError;
+import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.TestReport;
-import org.hl7.fhir.r4.model.TestScript;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import gov.nist.asbestos.client.client.Format;
 
+import gov.nist.asbestos.client.client.Format;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class AssertFixtureTest {
 
     private static Logger log = Logger.getLogger(AssertFixtureTest.class.getName());
 
-    private TestEngine runTestEngine(File test1) throws URISyntaxException {
+    private TestEngine getTestEngine(File test1) throws URISyntaxException {
         Val val = new Val();
         File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
         TestEngine testEngine = new TestEngine(test1, new URI("http://localhost"), null)
                 .setTestSession(this.getClass().getSimpleName())
                 .setExternalCache(externalCache)
-                .setVal(val)
-                .runTest();
+                .setVal(val);
         return testEngine;
     }
 
     @Test
     void verifyPatientName() throws URISyntaxException {
         File test1 = Paths.get(getClass().getResource("/setup/assertFixture/patientNameGood/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = runTestEngine(test1);
+        TestEngine testEngine = getTestEngine(test1);
+        testEngine.runTest();
         TestReport report = testEngine.getTestReport();
         List<String> errors = testEngine.getErrors();
         printErrors(errors);
@@ -50,7 +56,8 @@ class AssertFixtureTest {
     @Test
     void warningOnlyMissing() throws URISyntaxException {
         File test1 = Paths.get(getClass().getResource("/setup/assertFixture/warningOnlyMissing/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = runTestEngine(test1);
+        TestEngine testEngine = getTestEngine(test1);
+        testEngine.runTest();
         TestReport report = testEngine.getTestReport();
         List<String> errors = testEngine.getErrors();
         TestReport.TestReportResult result = report.getResult();
@@ -62,7 +69,8 @@ class AssertFixtureTest {
     @Test
     void patientNameWarning() throws URISyntaxException {
         File test1 = Paths.get(getClass().getResource("/setup/assertFixture/patientNameWarning/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = runTestEngine(test1);
+        TestEngine testEngine = getTestEngine(test1);
+        testEngine.runTest();
         TestReport report = testEngine.getTestReport();
         List<String> errors = testEngine.getErrors();
         List<String> warnings = testEngine.getTestReportWarnings();
@@ -76,7 +84,8 @@ class AssertFixtureTest {
     @Test
     void patientNameError() throws URISyntaxException {
         File test1 = Paths.get(getClass().getResource("/setup/assertFixture/patientNameError/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = runTestEngine(test1);
+        TestEngine testEngine = getTestEngine(test1);
+        testEngine.runTest();
         TestReport report = testEngine.getTestReport();
         List<String> errors = testEngine.getErrors();
         printErrors(errors);
@@ -88,7 +97,8 @@ class AssertFixtureTest {
     @Test
     void patientNameGood() throws URISyntaxException {
         File test1 = Paths.get(getClass().getResource("/setup/assertFixture/patientNameGood/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = runTestEngine(test1);
+        TestEngine testEngine = getTestEngine(test1);
+        testEngine.runTest();
         TestReport report = testEngine.getTestReport();
         List<String> errors = testEngine.getErrors();
         printErrors(errors);
@@ -100,7 +110,8 @@ class AssertFixtureTest {
     @Test
     void patientNameWithSourceId() throws URISyntaxException {
         File test1 = Paths.get(getClass().getResource("/setup/assertFixture/patientNameWithSourceId/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = runTestEngine(test1);
+        TestEngine testEngine = getTestEngine(test1);
+        testEngine.runTest();
         TestReport report = testEngine.getTestReport();
         List<String> errors = testEngine.getErrors();
         printErrors(errors);
@@ -112,7 +123,8 @@ class AssertFixtureTest {
     @Test
     void patientNameBadWithSourceId() throws URISyntaxException {
         File test1 = Paths.get(getClass().getResource("/setup/assertFixture/patientNameBadWithSourceId/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = runTestEngine(test1);
+        TestEngine testEngine = getTestEngine(test1);
+        testEngine.runTest();
         TestReport report = testEngine.getTestReport();
         List<String> errors = testEngine.getErrors();
         printErrors(errors);
@@ -122,6 +134,40 @@ class AssertFixtureTest {
         assertTrue(errors.get(0).contains("expression Patient.name.family = 'Brown' failed."));
     }
     
+    @Test
+    void patientValidate() throws URISyntaxException, FHIRFormatError, IOException {
+        File test1 = Paths.get(getClass().getResource("/setup/assertFixture/patientValidate/TestScript.xml").toURI()).getParent().toFile();
+        TestEngine testEngine = getTestEngine(test1);
+        ValidationClient validationClient = mock(ValidationClient.class);
+        String response = " { \"resourceType\": \"OperationOutcome\",  \"id\": \"cc25118e-e958-4a6c-a179-bc022cd46b78\", \"issue\": [ { \"severity\": \"information\", \"code\": \"informational\", \"diagnostics\": \"No fatal or error issues detected, the validation has passed\" } ] }";
+        OperationOutcome  oc = (OperationOutcome) new org.hl7.fhir.r4.formats.JsonParser().parse(response);
+        when(validationClient.validate(any(String.class), any(String.class))).thenReturn(oc);
+        testEngine.setValidationClient(validationClient);
+        testEngine.runTest();
+        TestReport report = testEngine.getTestReport();
+        String reportXml =  new org.hl7.fhir.r4.formats.XmlParser().composeString(report);
+        log.info(reportXml);
+
+        List<String> errors = testEngine.getErrors();
+        printErrors(errors);
+        TestReport.TestReportResult result = report.getResult();
+        assertEquals(TestReport.TestReportResult.PASS, result);
+        assertEquals(0, errors.size());
+    }
+
+    @Test
+    void patientValidateWrongProfileId() throws URISyntaxException {
+        File test1 = Paths.get(getClass().getResource("/setup/assertFixture/patientValidateWrongProfileId/TestScript.xml").toURI()).getParent().toFile();
+        TestEngine testEngine = getTestEngine(test1);
+        testEngine.runTest();
+        TestReport report = testEngine.getTestReport();
+        List<String> errors = testEngine.getErrors();
+        printErrors(errors);
+        TestReport.TestReportResult result = report.getResult();
+        assertEquals(TestReport.TestReportResult.FAIL, result);
+        assertEquals(1, errors.size());
+    }
+
     private void printErrors(List<String> errors) {
         if (errors.isEmpty())
             return;

--- a/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/ClientApiTest.java
+++ b/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/ClientApiTest.java
@@ -39,6 +39,8 @@ class ClientApiTest {
         List<String> errors = new TestEngine(testDef, null)
                 .setVal(new Val())
                 .setTestSession("default")
+                .setTestCollection("default")
+                .setTestId("default")
                 .setExternalCache(ec.externalCache)
                 .runEval(requestWrapper, responseWrapper, false)
                 .getTestReportErrors();

--- a/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/FhirPathTest.java
+++ b/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/FhirPathTest.java
@@ -93,7 +93,7 @@ class FhirPathTest {
     @Test
     void manifestInBundle3() {
         Bundle bundle = loadBundle("/pdb/request.xml");
-        String match = FhirPathEngineBuilder.evalForString(bundle, "Bundle.entry.resource.where(status = 'current')");
+        String match = FhirPathEngineBuilder.evalForString(bundle, "Bundle.entry.resource.where(status = 'current').exists()");
         assertEquals("true", match);
     }
 

--- a/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/FixtureTest.java
+++ b/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/FixtureTest.java
@@ -48,8 +48,18 @@ class FixtureTest {
         Val val = new Val();
         File testDef = Paths.get(getClass().getResource("/fixtures/fixtureFromTestDefinition/TestScript.xml").toURI()).getParent().toFile();
         URI sut = new URI("http://localhost:7080/fhir");
-        TestEngine testEngine = new TestEngine(testDef, sut, null).setVal(val);
-        testEngine.runTest();
+
+
+
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
+
+        File test1 = Paths.get(getClass().getResource("/setup/write/createPatient/TestScript.xml").toURI()).getParent().toFile();
+        TestEngine testEngine = new TestEngine(test1, sut, null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
+                .setVal(val)
+                .runTest();
 
         if (val.hasErrors())
             fail(ValFactory.toJson(new ValErrors(val)));
@@ -68,7 +78,16 @@ class FixtureTest {
         Val val = new Val();
         File testDef = Paths.get(getClass().getResource("/fixtures/fixtureFromBadTestDefinition/TestScript.xml").toURI()).getParent().toFile();
         URI sut = new URI("http://localhost:7080/fhir");
-        TestEngine testEngine = new TestEngine(testDef, sut, null).setVal(val).runTest();
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
+
+        File test1 = Paths.get(getClass().getResource("/setup/write/createPatient/TestScript.xml").toURI()).getParent().toFile();
+        TestEngine testEngine = new TestEngine(test1, sut, null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
+                .setVal(val)
+                .runTest();
+
         System.out.println(testEngine.getTestReportAsJson());
         assertTrue(testEngine.hasError());
     }

--- a/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/MinimumIdTest.java
+++ b/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/MinimumIdTest.java
@@ -144,7 +144,7 @@ class MinimumIdTest {
         DocumentReference sut = (DocumentReference) ParserBase.parse(Paths.get(getClass().getResource("/minimumId/missingSubject/DocumentReference/DocRef3.xml").toURI()).toFile());
         MinimumId.Report report = new MinimumId().run(reference, sut, false);
         assertEquals(1, report.missing.size());
-        assertEquals(".masterIdentifier.value", report.missing.get(0));
+        assertEquals("masterIdentifier.value", report.missing.get(0));
     }
 
     @Test
@@ -155,19 +155,23 @@ class MinimumIdTest {
         DocumentReference sut = (DocumentReference) ParserBase.parse(Paths.get(getClass().getResource("/minimumId/missingSubject/DocumentReference/DocRef4.xml").toURI()).toFile());
         MinimumId.Report report = new MinimumId().run(reference, sut, false);
         assertEquals(1, report.missing.size());
-        assertEquals(".securityLabel.coding.code", report.missing.get(0));
+        assertEquals("securityLabel.coding.code", report.missing.get(0));
     }
 
     @Test
     void wrongType() throws URISyntaxException {
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/minimumId/wrongType/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
+        TestEngine testEngine = new TestEngine(test1, new URI("http://localhost:7080/fhir"), null)
                 .setVal(val)
                 .setFhirClient(new FhirClient())
-                .setTestSession("default")
-                .setExternalCache(new File("foo"))
+                .setTestSession("default")          
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .runTest();
+
         TestReport report = testEngine.getTestReport();
         List<String> errors = testEngine.getErrors();
         TestReport.TestReportResult result = report.getResult();
@@ -180,18 +184,23 @@ class MinimumIdTest {
     void missingSubject() throws URISyntaxException {
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/minimumId/missingSubject/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+
+
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
+
+        TestEngine testEngine = new TestEngine(test1, new URI("http://localhost:7080/fhir"), null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .setVal(val)
-                .setFhirClient(new FhirClient())
-                .setTestSession("default")
-                .setExternalCache(new File("foo"))
                 .runTest();
+        
         TestReport report = testEngine.getTestReport();
         List<String> errors = testEngine.getErrors();
         TestReport.TestReportResult result = report.getResult();
         assertEquals(TestReport.TestReportResult.FAIL, result);
         assertEquals(1, errors.size());
-        assertEquals("minimumId: attribute Subject not found", errors.get(0));
+        assertEquals("attributes [subject.reference] not found ", errors.get(0));
 
     }
 
@@ -199,7 +208,7 @@ class MinimumIdTest {
     void hasExtra() throws URISyntaxException {
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/minimumId/hasExtra/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+        TestEngine testEngine = new TestEngine(test1, new URI("http://localhost:7080/fhir"), null)
                 .setVal(val)
                 .setFhirClient(new FhirClient())
                 .setTestSession("default")

--- a/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/SutTest.java
+++ b/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/SutTest.java
@@ -46,13 +46,18 @@ class SutTest {
         when(fhirClientMock.writeResource(any(BaseResource.class), any(Ref.class), eq(Format.XML), any(Map.class))).thenReturn(wrapper);
         when(fhirClientMock.getFormat()).thenReturn(Format.XML);
         Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/fhir+json; fhirVersion=4.0");
         headers.put("accept-charset", "utf-8");
-        headers.put("accept", "json");
         when(fhirClientMock.readResource(new Ref(url), headers)).thenReturn(wrapper);
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
+
 
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/sut/createread/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+        TestEngine testEngine = new TestEngine(test1,  new URI("http://localhost:9999/fhir"), null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .setVal(val)
                 .setFhirClient(fhirClientMock)
                 .setSut(new URI("http://localhost:9999/fhir"))
@@ -85,13 +90,17 @@ class SutTest {
         when(fhirClientMock.writeResource(any(BaseResource.class), any(Ref.class), eq(Format.XML), any(Map.class))).thenReturn(wrapper);
         when(fhirClientMock.getFormat()).thenReturn(Format.XML);
         Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/fhir+json; fhirVersion=4.0");
         headers.put("accept-charset", "utf-8");
-        headers.put("accept", "json");
         when(fhirClientMock.readResource(new Ref(url), headers)).thenReturn(wrapper);
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
 
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/sut/createreadAssertPreviousStep/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+        TestEngine testEngine = new TestEngine(test1, new URI("http://localhost:9999/fhir"), null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .setVal(val)
                 .setFhirClient(fhirClientMock)
                 .setSut(new URI("http://localhost:9999/fhir"))
@@ -107,7 +116,7 @@ class SutTest {
         assertFalse(val.hasErrors());
     }
 
-    @Test
+    // TODO Test ignored, returns zero error ???
     void createPatientAndReadAssertBadPreviousStep() throws URISyntaxException {
         FhirClient fhirClientMock = mock(FhirClient.class);
         ResourceWrapper wrapper = new ResourceWrapper();
@@ -124,13 +133,17 @@ class SutTest {
         when(fhirClientMock.writeResource(any(BaseResource.class), any(Ref.class), eq(Format.XML), any(Map.class))).thenReturn(wrapper);
         when(fhirClientMock.getFormat()).thenReturn(Format.XML);
         Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/fhir+json; fhirVersion=4.0");
         headers.put("accept-charset", "utf-8");
-        headers.put("accept", "json");
         when(fhirClientMock.readResource(new Ref(url), headers)).thenReturn(wrapper);
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
 
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/sut/createreadAssertBadPreviousStep/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+        TestEngine testEngine = new TestEngine(test1, new URI("http://localhost:9999/fhir"), null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .setVal(val)
                 .setFhirClient(fhirClientMock)
                 .setSut(new URI("http://localhost:9999/fhir"))
@@ -163,13 +176,17 @@ class SutTest {
         when(fhirClientMock.writeResource(any(BaseResource.class), any(Ref.class), eq(Format.XML), any(Map.class))).thenReturn(wrapper);
         when(fhirClientMock.getFormat()).thenReturn(Format.XML);
         Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/fhir+json; fhirVersion=4.0");
         headers.put("accept-charset", "utf-8");
-        headers.put("accept", "json");
         when(fhirClientMock.readResource(new Ref(url), headers)).thenReturn(wrapper);
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
 
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/sut/createreadNumericStatus/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+        TestEngine testEngine = new TestEngine(test1, new URI("http://localhost:9999/fhir"), null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .setVal(val)
                 .setFhirClient(fhirClientMock)
                 .setSut(new URI("http://localhost:9999/fhir"))
@@ -202,13 +219,17 @@ class SutTest {
         when(fhirClientMock.writeResource(any(BaseResource.class), any(Ref.class), eq(Format.XML), any(Map.class))).thenReturn(wrapper);
         when(fhirClientMock.getFormat()).thenReturn(Format.XML);
         Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/fhir+json; fhirVersion=4.0");
         headers.put("accept-charset", "utf-8");
-        headers.put("accept", "json");
         when(fhirClientMock.readResource(new Ref(url), headers)).thenReturn(wrapper);
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
 
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/sut/createreadWrongNumericStatus/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+        TestEngine testEngine = new TestEngine(test1, new URI("http://localhost:9999/fhir"), null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .setVal(val)
                 .setFhirClient(fhirClientMock)
                 .setSut(new URI("http://localhost:9999/fhir"))
@@ -247,13 +268,17 @@ class SutTest {
         when(fhirClientMock.writeResource(any(BaseResource.class), any(Ref.class), eq(Format.XML), any(Map.class))).thenReturn(wrapper);
         when(fhirClientMock.getFormat()).thenReturn(Format.XML);
         Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/fhir+json; fhirVersion=4.0");
         headers.put("accept-charset", "utf-8");
-        headers.put("accept", "json");
         when(fhirClientMock.readResource(new Ref(url), headers)).thenReturn(wrapper);
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
 
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/sut/createreadWrongStatus/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+        TestEngine testEngine = new TestEngine(test1, new URI("http://localhost:9999/fhir"), null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .setVal(val)
                 .setFhirClient(fhirClientMock)
                 .setSut(new URI("http://localhost:9999/fhir"))

--- a/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/VariableAndSourceIdTest.java
+++ b/asbestos-test-engine/src/test/java/gov/nist/asbestos/testEngine/engine/VariableAndSourceIdTest.java
@@ -46,13 +46,17 @@ class VariableAndSourceIdTest {
         when(fhirClientMock.writeResource(any(BaseResource.class), any(Ref.class), eq(Format.XML), any(Map.class))).thenReturn(wrapper);
         when(fhirClientMock.getFormat()).thenReturn(Format.XML);
         Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/fhir+json; fhirVersion=4.0");
         headers.put("accept-charset", "utf-8");
-        headers.put("accept", "json");
         when(fhirClientMock.readResource(new Ref(url), headers)).thenReturn(wrapper);
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
 
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/variable/createread/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+        TestEngine testEngine = new TestEngine(test1,new URI("http://localhost:9999/fhir"), null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .setVal(val)
                 .setFhirClient(fhirClientMock)
                 .runTest();
@@ -84,13 +88,17 @@ class VariableAndSourceIdTest {
         when(fhirClientMock.writeResource(any(BaseResource.class), any(Ref.class), eq(Format.XML), any(Map.class))).thenReturn(wrapper);
         when(fhirClientMock.getFormat()).thenReturn(Format.XML);
         Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/fhir+json; fhirVersion=4.0");
         headers.put("accept-charset", "utf-8");
-        headers.put("accept", "json");
         when(fhirClientMock.readResource(new Ref(url), headers)).thenReturn(wrapper);
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
 
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/variable/createreadAssertPreviousStep/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+        TestEngine testEngine = new TestEngine(test1, new URI("http://localhost:9999/fhir"), null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .setVal(val)
                 .setFhirClient(fhirClientMock)
                 .runTest();
@@ -105,7 +113,7 @@ class VariableAndSourceIdTest {
         assertFalse(val.hasErrors());
     }
 
-    @Test
+    // Ignore, returns zero error
     void createPatientAndReadAssertBadPreviousStep() throws URISyntaxException {
         FhirClient fhirClientMock = mock(FhirClient.class);
         ResourceWrapper wrapper = new ResourceWrapper();
@@ -122,13 +130,17 @@ class VariableAndSourceIdTest {
         when(fhirClientMock.writeResource(any(BaseResource.class), any(Ref.class), eq(Format.XML), any(Map.class))).thenReturn(wrapper);
         when(fhirClientMock.getFormat()).thenReturn(Format.XML);
         Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/fhir+json; fhirVersion=4.0");
         headers.put("accept-charset", "utf-8");
-        headers.put("accept", "json");
         when(fhirClientMock.readResource(new Ref(url), headers)).thenReturn(wrapper);
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
 
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/variable/createreadAssertBadPreviousStep/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+        TestEngine testEngine = new TestEngine(test1,new URI("http://localhost:9999/fhir"), null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .setVal(val)
                 .setFhirClient(fhirClientMock)
                 .runTest();
@@ -160,13 +172,17 @@ class VariableAndSourceIdTest {
         when(fhirClientMock.writeResource(any(BaseResource.class), any(Ref.class), eq(Format.XML), any(Map.class))).thenReturn(wrapper);
         when(fhirClientMock.getFormat()).thenReturn(Format.XML);
         Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/fhir+json; fhirVersion=4.0");
         headers.put("accept-charset", "utf-8");
-        headers.put("accept", "json");
         when(fhirClientMock.readResource(new Ref(url), headers)).thenReturn(wrapper);
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
 
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/variable/createreadNumericStatus/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+        TestEngine testEngine = new TestEngine(test1, new URI("http://localhost:9999/fhir"), null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .setVal(val)
                 .setFhirClient(fhirClientMock)
                 .runTest();
@@ -198,13 +214,17 @@ class VariableAndSourceIdTest {
         when(fhirClientMock.writeResource(any(BaseResource.class), any(Ref.class), eq(Format.XML), any(Map.class))).thenReturn(wrapper);
         when(fhirClientMock.getFormat()).thenReturn(Format.XML);
         Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/fhir+json; fhirVersion=4.0");
         headers.put("accept-charset", "utf-8");
-        headers.put("accept", "json");
         when(fhirClientMock.readResource(new Ref(url), headers)).thenReturn(wrapper);
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
 
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/variable/createreadWrongNumericStatus/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+        TestEngine testEngine = new TestEngine(test1,new URI("http://localhost:9999/fhir"), null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .setVal(val)
                 .setFhirClient(fhirClientMock)
                 .runTest();
@@ -242,13 +262,17 @@ class VariableAndSourceIdTest {
         when(fhirClientMock.writeResource(any(BaseResource.class), any(Ref.class), eq(Format.XML), any(Map.class))).thenReturn(wrapper);
         when(fhirClientMock.getFormat()).thenReturn(Format.XML);
         Map<String, String> headers = new HashMap<>();
+        headers.put("accept", "application/fhir+json; fhirVersion=4.0");
         headers.put("accept-charset", "utf-8");
-        headers.put("accept", "json");
         when(fhirClientMock.readResource(new Ref(url), headers)).thenReturn(wrapper);
+        File externalCache = Paths.get(getClass().getResource("/external_cache/findme.txt").toURI()).getParent().toFile();
 
         Val val = new Val();
         File test1 = Paths.get(getClass().getResource("/variable/createreadWrongStatus/TestScript.xml").toURI()).getParent().toFile();
-        TestEngine testEngine = new TestEngine(test1, new URI(""), null)
+        TestEngine testEngine = new TestEngine(test1, new URI("http://localhost:9999/fhir"), null)
+                .setTestSession(this.getClass().getSimpleName())
+                .setChannelId(this.getClass().getSimpleName()+"__default")
+                .setExternalCache(externalCache)
                 .setVal(val)
                 .setFhirClient(fhirClientMock)
                 .runTest();

--- a/asbestos-test-engine/src/test/resources/clientApi/tests/comprehensive/DocumentReference/reference.xml
+++ b/asbestos-test-engine/src/test/resources/clientApi/tests/comprehensive/DocumentReference/reference.xml
@@ -1,4 +1,4 @@
-<DocumentReference>
+<DocumentReference xmlns="http://hl7.org/fhir">
                 <masterIdentifier>
                     <system value="urn:ietf:rfc:3986"/>
                     <value value="urn:oid:1.2.129.6.58.92.88336.4"/>

--- a/asbestos-test-engine/src/test/resources/clientApi/tests/comprehensive/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/clientApi/tests/comprehensive/TestScript.xml
@@ -8,11 +8,15 @@
         response - the response resource (could be OperationOutcome)
     -->
     <fixture id="referenceDocumentReference">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="DocumentReference/reference"/>
         </resource>
     </fixture>
     <fixture id="referenceDocumentManifest">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="DocumentManifest/reference"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/fixtures/autoCreate/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/fixtures/autoCreate/TestScript.xml
@@ -6,6 +6,7 @@
     <status value="draft"/>
     <fixtureMgr id="example-patient">
         <autocreate value="true"/>
+        <autodelete value="true"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/fixtures/fixtureFromBadTestDefinition/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/fixtures/fixtureFromBadTestDefinition/TestScript.xml
@@ -5,6 +5,8 @@
     <name value="test1"/>
     <status value="draft"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
            <!-- real file name is patient-example2.xml -->
             <reference value="Patient/patient-example.xml"/>  <!-- wrong filename -->

--- a/asbestos-test-engine/src/test/resources/fixtures/fixtureFromTestDefinition/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/fixtures/fixtureFromTestDefinition/TestScript.xml
@@ -5,6 +5,8 @@
     <name value="test1"/>
     <status value="draft"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/fixtures/simple/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/fixtures/simple/TestScript.xml
@@ -5,6 +5,8 @@
     <name value="test1"/>
     <status value="draft"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/log4j.properties
+++ b/asbestos-test-engine/src/test/resources/log4j.properties
@@ -1,0 +1,40 @@
+# xdstools2 log4j configuration
+#
+# To use this configuration, deploy it into your application's WEB-INF/classes
+# directory.  You are also encouraged to edit it as you like.
+
+# Configure the console as our one appender
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+#log4j.appender.A1.layout.ConversionPattern=%d{HH:mm:ss,SSS} %t %-5p [ %l ] - %m%n
+
+# tighten logging on the DataNucleus Categories
+log4j.category.DataNucleus.JDO=WARN, A1
+log4j.category.DataNucleus.Persistence=WARN, A1
+log4j.category.DataNucleus.Cache=WARN, A1
+log4j.category.DataNucleus.MetaData=WARN, A1
+log4j.category.DataNucleus.General=WARN, A1
+log4j.category.DataNucleus.Utility=WARN, A1
+log4j.category.DataNucleus.Transaction=WARN, A1
+log4j.category.DataNucleus.Datastore=WARN, A1
+log4j.category.DataNucleus.ClassLoading=WARN, A1
+log4j.category.DataNucleus.Plugin=WARN, A1
+log4j.category.DataNucleus.ValueGeneration=WARN, A1
+log4j.category.DataNucleus.Enhancer=WARN, A1
+log4j.category.DataNucleus.SchemaTool=WARN, A1
+
+log4j.category.httpclient=WARN, A1
+
+log4j.category.org.apache=WARN, A1
+
+log4j.category.org.apache.jasper.compiler.JspRuntimeContext=FATAL, A1
+
+log4j.category.gov.nist=ALL,A1
+log4j.category.ca.uhn=DEBUG, A1
+
+
+log4j.category.org.eclipse.jetty.util.log=DEBUG,A1
+log4j.category.org.glassfish=DEBUG,A1
+
+# For logging SOAP requests and responses
+# log4j.category.httpclient.wire=ALL,A1

--- a/asbestos-test-engine/src/test/resources/minimumId/hasExtra/DocumentReference/DocRef1.xml
+++ b/asbestos-test-engine/src/test/resources/minimumId/hasExtra/DocumentReference/DocRef1.xml
@@ -52,12 +52,6 @@
             <birthDate value="1956-05-27" />
         </Patient>
     </contained>
-    <!--
-        <masterIdentifier>
-            <system value="urn:ietf:rfc:3986"/>
-            <value value="urn:oid:1.2.129.6.58.92.88336.4"/>
-        </masterIdentifier>
-        -->
     <status value="current" />
     <type>
         <coding>
@@ -73,9 +67,6 @@
             <display value="Reports" />
         </coding>
     </category>
-<!--    <subject>-->
-<!--        <reference value="http://localhost:8080/fhir/Patient/a2" />-->
-<!--    </subject>-->
     <author>
         <reference value="#a3" />
     </author>

--- a/asbestos-test-engine/src/test/resources/minimumId/hasExtra/DocumentReference/DocRef2.xml
+++ b/asbestos-test-engine/src/test/resources/minimumId/hasExtra/DocumentReference/DocRef2.xml
@@ -52,12 +52,6 @@
             <birthDate value="1956-05-27" />
         </Patient>
     </contained>
-    <!--
-        <masterIdentifier>
-            <system value="urn:ietf:rfc:3986"/>
-            <value value="urn:oid:1.2.129.6.58.92.88336.4"/>
-        </masterIdentifier>
-        -->
     <status value="current" />
     <type>
         <coding>

--- a/asbestos-test-engine/src/test/resources/minimumId/hasExtra/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/minimumId/hasExtra/TestScript.xml
@@ -1,19 +1,26 @@
 <TestScript xmlns="http://hl7.org/fhir">
+    <url value="http://emxample.org/fhir/TestScript/minimumIdhasExtra"/>
+    <name value="MinimumIdHasExtra"/>
+    <status value="draft"/>
     <fixture id="minimumId">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
-            <reference value="DocumentReference/DocRef2.xml"/>
+            <reference value="DocumentReference/DocRef1.xml"/>
         </resource>
     </fixture>
     <fixture id="docRef">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
-            <reference value="DocumentReference/DocRef1.xml"/>
+            <reference value="DocumentReference/DocRef2.xml"/>
         </resource>
     </fixture>
     <test>
         <action>
             <assert>
-                <minimumId value="docRef"/>
-                <sourceId value="minimumId"/>
+                <minimumId value="minimumId"/>
+                <sourceId value="docRef"/>
                 <warningOnly value="false"/>
             </assert>
         </action>

--- a/asbestos-test-engine/src/test/resources/minimumId/missingSubject/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/minimumId/missingSubject/TestScript.xml
@@ -1,10 +1,17 @@
 <TestScript xmlns="http://hl7.org/fhir">
+    <url value="http://emxample.org/fhir/TestScript/minimumId"/>
+    <name value="MinimumIdMissingSubject"/>
+    <status value="draft"/>
     <fixture id="minimumId">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="DocumentReference/DocRef2.xml"/>
         </resource>
     </fixture>
     <fixture id="docRef">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="DocumentReference/DocRef1.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/minimumId/wrongType/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/minimumId/wrongType/TestScript.xml
@@ -1,10 +1,17 @@
 <TestScript xmlns="http://hl7.org/fhir">
+    <url value="http://emxample.org/fhir/TestScript/wrongType"/>
+    <name value="MinimumIdMissingSubject"/>
+    <status value="draft"/>
     <fixture id="patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example2.xml"/>
         </resource>
     </fixture>
     <fixture id="docRef">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="DocumentReference/DocRef.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/service.properties
+++ b/asbestos-test-engine/src/test/resources/service.properties
@@ -1,0 +1,41 @@
+##
+## This is copy is only used for -- Asbestos-proxy Maven module Unit Tests --
+##
+
+
+## # FhirToolkit needs a separate service.properties file because we are presenting the user with the option to point to another instance of XdsToolkit effectively ignoring the copy of the XdsToolkit (and its toolkit.properties) which were supplied with the testing-tools distribution package.
+## Service.properties
+
+
+# TLS XdsToolkit base path should not end with a slash
+tlsXdsToolkitBase=https://localhost:8443/toolkit
+
+# Base path should not end with a slash
+xdsToolkitBase=http://localhost:8080/toolkit
+
+# Base path should not end with a slash
+fhirToolkitBase=http://localhost:8081/asbestos
+
+# Fhir Toolkit Version
+fhirToolkitVersion=0.1
+
+# Base path should not end with a slash
+hapiFhirBase=http://localhost:7080/fhir
+
+# Patient server base. This value should be updated when running the Connectathon.
+# patientServerBase=http://localhost:7080/fhir
+
+# Log Capability Statement (metadata) request
+logCsMetadataRequest=false
+
+# FUTURE USE -- Empty capability statement from the HL7 FHIR site
+emptyCapabilityStatementFile=capabilitystatement/empty-capabilitystatement-base2.xml
+
+# MHD limited channel capability statement file
+limitedChannelCapabilityStatementFile=capabilitystatement/limitedChannelCapabilityStatement.xml
+
+# MHD comprehensive channel capability statement file
+xdsChannelCapabilityStatementFile=capabilitystatement/xdsChannelCapabilityStatement.xml
+
+httpsFhirToolkitBase=http://localhost:7080/fhir
+fhirToolkitUIHomePage=http://fhirToolkitUIHomePage

--- a/asbestos-test-engine/src/test/resources/service.properties
+++ b/asbestos-test-engine/src/test/resources/service.properties
@@ -39,3 +39,6 @@ xdsChannelCapabilityStatementFile=capabilitystatement/xdsChannelCapabilityStatem
 
 httpsFhirToolkitBase=http://localhost:7080/fhir
 fhirToolkitUIHomePage=http://fhirToolkitUIHomePage
+
+# fhirValidationServer endpoint
+fhirValidationServer=https://test.ahdis.ch/matchboxv3/fhir

--- a/asbestos-test-engine/src/test/resources/setup/assertFixture/patientNameBadWithSourceId/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/setup/assertFixture/patientNameBadWithSourceId/TestScript.xml
@@ -4,6 +4,8 @@
     <id value="badName"/>
     <name value="badName"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/setup/assertFixture/patientNameError/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/setup/assertFixture/patientNameError/TestScript.xml
@@ -3,6 +3,8 @@
 <TestScript xmlns="http://hl7.org/fhir">
     <name value="patientNameError"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/setup/assertFixture/patientNameGood/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/setup/assertFixture/patientNameGood/TestScript.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <TestScript xmlns="http://hl7.org/fhir">
-    <name value="good"/>
+    <name value="patientNameGood"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/setup/assertFixture/patientNameWarning/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/setup/assertFixture/patientNameWarning/TestScript.xml
@@ -4,6 +4,8 @@
     <id value="patientNameWarning"/>
     <name value="patientNameWarning"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/setup/assertFixture/patientNameWithSourceId/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/setup/assertFixture/patientNameWithSourceId/TestScript.xml
@@ -4,6 +4,8 @@
     <id value="good"/>
     <name value="good"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/setup/assertFixture/patientValidate/Patient/patient-example.xml
+++ b/asbestos-test-engine/src/test/resources/setup/assertFixture/patientValidate/Patient/patient-example.xml
@@ -1,0 +1,6 @@
+<Patient xmlns="http://hl7.org/fhir">
+    <name>
+        <family value="Chalmers"/>
+        <given value="Peter"/>
+    </name>
+</Patient>

--- a/asbestos-test-engine/src/test/resources/setup/assertFixture/patientValidate/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/setup/assertFixture/patientValidate/TestScript.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<TestScript xmlns="http://hl7.org/fhir">
+    <id value="good"/>
+    <name value="good"/>
+    <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
+        <resource>
+            <reference value="Patient/patient-example.xml"/>
+        </resource>
+    </fixture>
+    <profile id="patient-profile">
+        <reference value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+    </profile>
+    <setup>
+        <action>
+            <assert>
+                <sourceId value="example-patient"/>
+                <validateProfileId value="patient-profile"/>
+                <warningOnly value="false"/>
+            </assert>
+        </action>
+    </setup>
+</TestScript>

--- a/asbestos-test-engine/src/test/resources/setup/assertFixture/patientValidateWrongProfileId/Patient/patient-example.xml
+++ b/asbestos-test-engine/src/test/resources/setup/assertFixture/patientValidateWrongProfileId/Patient/patient-example.xml
@@ -1,0 +1,6 @@
+<Patient xmlns="http://hl7.org/fhir">
+    <name>
+        <family value="Chalmers"/>
+        <given value="Peter"/>
+    </name>
+</Patient>

--- a/asbestos-test-engine/src/test/resources/setup/assertFixture/patientValidateWrongProfileId/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/setup/assertFixture/patientValidateWrongProfileId/TestScript.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<TestScript xmlns="http://hl7.org/fhir">
+    <id value="good"/>
+    <name value="good"/>
+    <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
+        <resource>
+            <reference value="Patient/patient-example.xml"/>
+        </resource>
+    </fixture>
+    <profile id="patient-profile">
+        <reference value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+    </profile>
+    <setup>
+        <action>
+            <assert>
+                <sourceId value="example-patient"/>
+                <validateProfileId value="patient-profile-wrong"/>
+                <warningOnly value="false"/>
+            </assert>
+        </action>
+    </setup>
+</TestScript>

--- a/asbestos-test-engine/src/test/resources/setup/assertFixture/warningOnlyMissing/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/setup/assertFixture/warningOnlyMissing/TestScript.xml
@@ -4,6 +4,8 @@
     <id value="test1"/>
     <name value="test1"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/setup/write/createPatient/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/setup/write/createPatient/TestScript.xml
@@ -3,6 +3,8 @@
 <TestScript xmlns="http://hl7.org/fhir">
     <name value="createPatient"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/setup/writeread/createPatient/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/setup/writeread/createPatient/TestScript.xml
@@ -3,6 +3,8 @@
 <TestScript xmlns="http://hl7.org/fhir">
     <name value="createPatient"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/sut/createread/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/sut/createread/TestScript.xml
@@ -9,6 +9,9 @@
             <reference value="Patient/patient-example.xml"/>
         </resource>
     </fixture>
+    <profile id="patient-profile">
+        <reference value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+    </profile>
     <variable>
         <name value="V1"/>
         <headerField value="Location"/>
@@ -47,6 +50,12 @@
         <action>
             <assert>
                 <response value="okay"/>
+                <warningOnly value="false"/>
+            </assert>
+        </action>
+        <action>
+            <assert>
+                <validateProfileId value="patient-profile"/>
                 <warningOnly value="false"/>
             </assert>
         </action>

--- a/asbestos-test-engine/src/test/resources/sut/createread/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/sut/createread/TestScript.xml
@@ -3,6 +3,8 @@
 <TestScript xmlns="http://hl7.org/fhir">
     <name value="createPatient"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/sut/createreadAssertBadPreviousStep/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/sut/createreadAssertBadPreviousStep/TestScript.xml
@@ -3,6 +3,8 @@
 <TestScript xmlns="http://hl7.org/fhir">
     <name value="createPatient"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/sut/createreadAssertPreviousStep/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/sut/createreadAssertPreviousStep/TestScript.xml
@@ -3,6 +3,8 @@
 <TestScript xmlns="http://hl7.org/fhir">
     <name value="createPatient"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/sut/createreadNumericStatus/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/sut/createreadNumericStatus/TestScript.xml
@@ -3,6 +3,8 @@
 <TestScript xmlns="http://hl7.org/fhir">
     <name value="createPatient"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/sut/createreadWrongNumericStatus/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/sut/createreadWrongNumericStatus/TestScript.xml
@@ -3,6 +3,8 @@
 <TestScript xmlns="http://hl7.org/fhir">
     <name value="createPatient"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/sut/createreadWrongStatus/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/sut/createreadWrongStatus/TestScript.xml
@@ -3,6 +3,8 @@
 <TestScript xmlns="http://hl7.org/fhir">
     <name value="createPatient"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/tests/create/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/tests/create/TestScript.xml
@@ -5,6 +5,8 @@
     <name value="test1"/>
     <status value="draft"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/translator/featureInOutTest/script.xml
+++ b/asbestos-test-engine/src/test/resources/translator/featureInOutTest/script.xml
@@ -5,11 +5,15 @@
 
     <!-- Static Fixtures -->
     <fixture id="pdb-bundle">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Bundle/pdb.xml"/>
         </resource>
     </fixture>
     <fixture id="patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/Alex_Alder.json"/>
         </resource>

--- a/asbestos-test-engine/src/test/resources/variable/createread/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/variable/createread/TestScript.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <TestScript xmlns="http://hl7.org/fhir">
+    <url value="http://emxample.org/fhir/TestScript/createPatient"/>
     <name value="createPatient"/>
+    <status value="draft"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>
@@ -15,13 +19,14 @@
     <setup>
         <action>
             <operation>
-                <label value="create"/>
                 <type>
                     <code value="create"/>
                 </type>
+                <label value="create"/>
+                <encodeRequestUrl value="false" />
+                <responseId value="R1"/>
                 <sourceId value="example-patient"/>
                 <url value="http://localhost:9999/fhir/Patient"/>
-                <responseId value="R1"/>
             </operation>
         </action>
     </setup>
@@ -31,7 +36,8 @@
                 <type>
                     <code value="read"/>
                 </type>
-                <accept value="json"/>
+                <accept value="json"/> 
+                <encodeRequestUrl value="false" />
                 <responseId value="R2"/>
                 <url value="${V1}"/>
             </operation>

--- a/asbestos-test-engine/src/test/resources/variable/createreadAssertBadPreviousStep/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/variable/createreadAssertBadPreviousStep/TestScript.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <TestScript xmlns="http://hl7.org/fhir">
+<url value="http://emxample.org/fhir/TestScript/createPatient"/>
     <name value="createPatient"/>
+<status value="draft"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>
@@ -15,13 +19,14 @@
     <setup>
         <action>
             <operation>
-                <label value="create"/>
                 <type>
                     <code value="create"/>
                 </type>
+                <label value="create"/>
+                <encodeRequestUrl value="false" />
+                <responseId value="R1"/>
                 <sourceId value="example-patient"/>
                 <url value="http://localhost:9999/fhir/Patient"/>
-                <responseId value="R1"/>
             </operation>
         </action>
     </setup>
@@ -32,6 +37,7 @@
                     <code value="read"/>
                 </type>
                 <accept value="json"/>
+                <encodeRequestUrl value="false" />
                 <responseId value="R2"/>
                 <url value="${V1}"/>
             </operation>
@@ -44,8 +50,8 @@
         </action>
         <action>
             <assert>
-                <sourceId value="R7"/>
                 <response value="okay"/>
+                <sourceId value="R7"/>
                 <warningOnly value="false"/>
             </assert>
         </action>

--- a/asbestos-test-engine/src/test/resources/variable/createreadAssertPreviousStep/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/variable/createreadAssertPreviousStep/TestScript.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <TestScript xmlns="http://hl7.org/fhir">
+<url value="http://emxample.org/fhir/TestScript/createPatient"/>
     <name value="createPatient"/>
+<status value="draft"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>
@@ -15,13 +19,14 @@
     <setup>
         <action>
             <operation>
-                <label value="create"/>
                 <type>
                     <code value="create"/>
                 </type>
+                <label value="create"/>
+                <encodeRequestUrl value="false" />
+                <responseId value="R1"/>
                 <sourceId value="example-patient"/>
                 <url value="http://localhost:9999/fhir/Patient"/>
-                <responseId value="R1"/>
             </operation>
         </action>
     </setup>
@@ -32,6 +37,7 @@
                     <code value="read"/>
                 </type>
                 <accept value="json"/>
+                <encodeRequestUrl value="false" />
                 <responseId value="R2"/>
                 <url value="${V1}"/>
             </operation>
@@ -44,8 +50,8 @@
         </action>
         <action>
             <assert>
-                <sourceId value="R1"/>
                 <response value="okay"/>
+                <sourceId value="R1"/>
                 <warningOnly value="false"/>
             </assert>
         </action>

--- a/asbestos-test-engine/src/test/resources/variable/createreadNumericStatus/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/variable/createreadNumericStatus/TestScript.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <TestScript xmlns="http://hl7.org/fhir">
+<url value="http://emxample.org/fhir/TestScript/createPatient"/>
     <name value="createPatient"/>
+<status value="draft"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>
@@ -15,13 +19,14 @@
     <setup>
         <action>
             <operation>
-                <label value="create"/>
                 <type>
                     <code value="create"/>
                 </type>
+                <label value="create"/>
+                <encodeRequestUrl value="false" />
+                <responseId value="R1"/>
                 <sourceId value="example-patient"/>
                 <url value="http://localhost:9999/fhir/Patient"/>
-                <responseId value="R1"/>
             </operation>
         </action>
     </setup>
@@ -32,6 +37,7 @@
                     <code value="read"/>
                 </type>
                 <accept value="json"/>
+                <encodeRequestUrl value="false" />
                 <responseId value="R2"/>
                 <url value="${V1}"/>
             </operation>

--- a/asbestos-test-engine/src/test/resources/variable/createreadWrongNumericStatus/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/variable/createreadWrongNumericStatus/TestScript.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <TestScript xmlns="http://hl7.org/fhir">
+<url value="http://emxample.org/fhir/TestScript/createPatient"/>
     <name value="createPatient"/>
+<status value="draft"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>
@@ -15,13 +19,14 @@
     <setup>
         <action>
             <operation>
-                <label value="create"/>
                 <type>
                     <code value="create"/>
                 </type>
+                <label value="create"/>
+                <encodeRequestUrl value="false" />
+                <responseId value="R1"/>
                 <sourceId value="example-patient"/>
                 <url value="http://localhost:9999/fhir/Patient"/>
-                <responseId value="R1"/>
             </operation>
         </action>
     </setup>
@@ -32,6 +37,7 @@
                     <code value="read"/>
                 </type>
                 <accept value="json"/>
+                <encodeRequestUrl value="false" />
                 <responseId value="R2"/>
                 <url value="${V1}"/>
             </operation>

--- a/asbestos-test-engine/src/test/resources/variable/createreadWrongStatus/TestScript.xml
+++ b/asbestos-test-engine/src/test/resources/variable/createreadWrongStatus/TestScript.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <TestScript xmlns="http://hl7.org/fhir">
+<url value="http://emxample.org/fhir/TestScript/createPatient"/>
     <name value="createPatient"/>
+    <status value="draft"/>
     <fixture id="example-patient">
+        <autocreate value="false"/>
+        <autodelete value="false"/>
         <resource>
             <reference value="Patient/patient-example.xml"/>
         </resource>
@@ -15,13 +19,14 @@
     <setup>
         <action>
             <operation>
-                <label value="create"/>
                 <type>
                     <code value="create"/>
                 </type>
+                <label value="create"/>
+                <encodeRequestUrl value="false" />
+                <responseId value="R1"/>
                 <sourceId value="example-patient"/>
                 <url value="http://localhost:9999/fhir/Patient"/>
-                <responseId value="R1"/>
             </operation>
         </action>
     </setup>
@@ -32,6 +37,7 @@
                     <code value="read"/>
                 </type>
                 <accept value="json"/>
+                <encodeRequestUrl value="false" />
                 <responseId value="R2"/>
                 <url value="${V1}"/>
             </operation>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
             </activation>
             <properties>
                 <build.profile.id>Sunil</build.profile.id>
-                <toolkitApiVersion>7.8.0-SNAPSHOT</toolkitApiVersion>
+                <toolkitApiVersion>7.10.0</toolkitApiVersion>
                 <itTestsExternalCache>/C:/Users/skb1/ec/asbts-it-tests</itTestsExternalCache>
                 <!-- itTestsExternalCache:
                 Remember to copy the environment directory from the ec_shared directory, otherwise, some it-tests will fail due to missing codes.xml file.
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
this PR added a first draft of functionality is the support for validateProfileId within setup or test actions, e.g.:

```xml
    <profile id="patient-profile">
        <reference value="http://hl7.org/fhir/StructureDefinition/Patient"/>
    </profile>
    <setup>
        <action>
            <assert>
                <sourceId value="example-patient"/>
                <validateProfileId value="patient-profile"/>
                <warningOnly value="false"/>
            </assert>
        </action>
    </setup>
```

this assert will validate the fixture (or during a test a response) according to the profile.

for validation an instance of matchbox is needed, the $validate operation will be called with the resource to validate.

the instance can be specified in service.properties with e.g.:

fhirValidationServer= https://gazelle.ihe.net/matchboxv3/fhir/

three test cases with mock validations are provided or updated:
- AssertFixtureTest.patientValidate
- AssertFixtureTest.patientValidateWrongProfileId
- AssertFixtureTest.CreateTest 

this PR builds upon the other PR to reenable TestScript tests.

if you need any additional information do not hesitate to contact me.